### PR TITLE
Only publish relevant files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
     "automation"
   ],
   "main": "./src/index.js",
+  "files": [
+    "/src/**/*.js"
+  ],
+  "directories": {
+    "lib": "./lib"
+  },
   "scripts": {
     "lint": "eslint --fix ./src/ ./tests/",
     "test": "mocha ./tests/"


### PR DESCRIPTION
Don't include test or other files when publishing to npm.